### PR TITLE
green_onion no longer working with latest rainbow gem version, updated

### DIFF
--- a/lib/green_onion.rb
+++ b/lib/green_onion.rb
@@ -4,7 +4,7 @@ require "green_onion/compare"
 require "green_onion/configuration"
 require "green_onion/errors"
 require "green_onion/browser"
-require "rainbow"
+require "rainbow/ext/string"
 
 module GreenOnion
   class << self
@@ -71,7 +71,7 @@ module GreenOnion
     # This is used in skin_percentage to raise error if a set of skins are ok or not
     def threshold_alert(actual, threshold)
       if actual > threshold
-        abort "#{actual - threshold}% above threshold set @ #{threshold}%".color(:red) + 
+        abort "#{actual - threshold}\% above threshold set @ #{threshold}%".color(:red) + 
         "\npixels changed (%):     #{@compare.percentage_changed}%" +
         "\npixels changed/total:  #{@compare.changed_px}/#{@compare.total_px}"
       else


### PR DESCRIPTION
I’m a student with “The Flatiron School”, a coding boot camp, and they use your green_onion gem for a html/css lab we have to complete.  I’m running the latest version of green_onion (0.1.4).  When running a spec test, I kept getting the following error: 

NoMethodError:
       undefined method `color' for "http://localhost:8000/index.html":String
     # /Users/Efrain/.rvm/gems/ruby-2.2.3/gems/green_onion-0.1.4/lib/green_onion.rb:58:in`skin_picker'
     # /Users/Efrain/.rvm/gems/ruby-2.2.3/gems/green_onion-0.1.4/lib/green_onion.rb:46:in `skin_visual’

So I went into my local green_onion.rb file, saw that it requires the rainbow gem, which is now up to version 2.x.  The NoMethodError is happening because since rainbow 2.x, to use the mixin methods to call #color directly on a String requires “rainbow/ext/string” and not just “rainbow”.  See http://www.rubydoc.info/gems/rainbow#String_mixin

So in green_onion.rb, I changed line 7 to require “rainbow/ext/string”, and I also noticed that on line 74, a ‘%’ used in a double quoted string wasn’t escaped, so I fixed that too.  So I just wanted to see if you could update these changes so that people with the latest version of ‘rainbow' can still use your helpful gem.  Thanks for reading.
